### PR TITLE
Protect private build sources in GitHub Actions

### DIFF
--- a/.github/workflows/LinuxBuild.yml
+++ b/.github/workflows/LinuxBuild.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: LinuxBuild
     runs-on: ubuntu-24.04
+    environment: private-build
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -18,6 +19,7 @@ jobs:
           haxe-version: 4.3.7
 
       - name: Restore private GameAnalytics
+        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}

--- a/.github/workflows/MacBuild.yml
+++ b/.github/workflows/MacBuild.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: macOS
     runs-on: macos-${{matrix.version}}
+    environment: private-build
     strategy:
       matrix:
         version: [14, 15]
@@ -21,6 +22,7 @@ jobs:
           haxe-version: 4.3.7
 
       - name: Restore private GameAnalytics
+        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}

--- a/.github/workflows/MobileBuild.yml
+++ b/.github/workflows/MobileBuild.yml
@@ -27,6 +27,7 @@ on:
 jobs: 
   Android:
     runs-on: macos-14
+    environment: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && 'public-build' || 'private-build' }}
     concurrency:
       group: ${{ github.workflow }}-Android-${{ github.ref }}
 
@@ -52,6 +53,7 @@ jobs:
           haxe-version: 4.3.7
 
       - name: Restore private GameAnalytics
+        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}
@@ -189,6 +191,7 @@ jobs:
           
   iOS:
     runs-on: macos-15
+    environment: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && 'public-build' || 'private-build' }}
     concurrency:
       group: ${{ github.workflow }}-iOS-${{ github.ref }}
 
@@ -207,6 +210,7 @@ jobs:
           haxe-version: 4.3.7
 
       - name: Restore private GameAnalytics
+        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}

--- a/.github/workflows/WindowsBuild.yml
+++ b/.github/workflows/WindowsBuild.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   Windows:
     runs-on: windows-latest
+    environment: private-build
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -17,6 +18,7 @@ jobs:
           haxe-version: 4.3.7
 
       - name: Restore private GameAnalytics
+        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}

--- a/.github/workflows/WindowsZGCBuild.yml
+++ b/.github/workflows/WindowsZGCBuild.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   Windows-ZGC:
     runs-on: windows-latest
+    environment: private-build
     timeout-minutes: 180
     env:
       HXCPP_COMPILE_JOBS: 4
@@ -77,6 +78,7 @@ jobs:
           }
 
       - name: Restore private GameAnalytics
+        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,6 +11,7 @@ jobs:
   buildAndroid:
     name: buildAndroid
     runs-on: ubuntu-latest
+    environment: private-build
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -33,6 +34,7 @@ jobs:
           haxe-version: 4.3.7
 
       - name: Restore private GameAnalytics
+        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}


### PR DESCRIPTION
## What changed
- bind Windows, Windows ZGC, Linux, macOS, Android, and iOS build jobs to the protected `private-build` environment
- route pull-request mobile builds through the secret-free `public-build` environment
- skip private GameAnalytics restoration for `pull_request` and `pull_request_target` events

## Security boundary
- complete private sources are stored separately in the organization-private `FNF-NovaFlare-Engine-Private` repository
- private source secrets are environment-scoped and `private-build` is restricted to the `main` branch
- the private repository is not shared as a cross-repository Action
- external collaborators keep public read/fork/PR access but no longer have write or manual workflow-run permission

## Validation
- `actionlint` passes for all workflows
- `git diff --check` passes
- the three remote private source files match the local files by SHA-256
- no real private source file is tracked by the public repository