### PR TITLE
Fix Windows ZGC native toolchain

### DIFF
--- a/.github/workflows/LinuxBuild.yml
+++ b/.github/workflows/LinuxBuild.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: LinuxBuild
     runs-on: ubuntu-24.04
-    environment: private-build
+    environment: ${{ github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && 'private-build' || 'public-build' }}
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -19,7 +19,7 @@ jobs:
           haxe-version: 4.3.7
 
       - name: Restore private GameAnalytics
-        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+        if: github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}

--- a/.github/workflows/LinuxBuild.yml
+++ b/.github/workflows/LinuxBuild.yml
@@ -25,7 +25,7 @@ jobs:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}
           NOVA_GA_TYPES_B64: ${{ secrets.NOVA_GA_TYPES_B64 }}
           NOVA_GA_CONFIG_B64: ${{ secrets.NOVA_GA_CONFIG_B64 }}
-        run: ./tools/restore-private-gameanalytics.ps1
+        run: ./tools/restore-private-gameanalytics.ps1 -Required
 
       - name: Installing LibVLC
         run: |

--- a/.github/workflows/MacBuild.yml
+++ b/.github/workflows/MacBuild.yml
@@ -28,7 +28,7 @@ jobs:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}
           NOVA_GA_TYPES_B64: ${{ secrets.NOVA_GA_TYPES_B64 }}
           NOVA_GA_CONFIG_B64: ${{ secrets.NOVA_GA_CONFIG_B64 }}
-        run: ./tools/restore-private-gameanalytics.ps1
+        run: ./tools/restore-private-gameanalytics.ps1 -Required
 
       - name: Determine cache strategy
         id: cache_strategy

--- a/.github/workflows/MacBuild.yml
+++ b/.github/workflows/MacBuild.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: macOS
     runs-on: macos-${{matrix.version}}
-    environment: private-build
+    environment: ${{ github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && 'private-build' || 'public-build' }}
     strategy:
       matrix:
         version: [14, 15]
@@ -22,7 +22,7 @@ jobs:
           haxe-version: 4.3.7
 
       - name: Restore private GameAnalytics
-        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+        if: github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}

--- a/.github/workflows/MobileBuild.yml
+++ b/.github/workflows/MobileBuild.yml
@@ -59,7 +59,7 @@ jobs:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}
           NOVA_GA_TYPES_B64: ${{ secrets.NOVA_GA_TYPES_B64 }}
           NOVA_GA_CONFIG_B64: ${{ secrets.NOVA_GA_CONFIG_B64 }}
-        run: ./tools/restore-private-gameanalytics.ps1
+        run: ./tools/restore-private-gameanalytics.ps1 -Required
               
       - name: Determine Android cache strategy
         id: android_cache
@@ -216,7 +216,7 @@ jobs:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}
           NOVA_GA_TYPES_B64: ${{ secrets.NOVA_GA_TYPES_B64 }}
           NOVA_GA_CONFIG_B64: ${{ secrets.NOVA_GA_CONFIG_B64 }}
-        run: ./tools/restore-private-gameanalytics.ps1
+        run: ./tools/restore-private-gameanalytics.ps1 -Required
    
       - name: Determine iOS cache strategy
         id: ios_cache

--- a/.github/workflows/MobileBuild.yml
+++ b/.github/workflows/MobileBuild.yml
@@ -27,7 +27,7 @@ on:
 jobs: 
   Android:
     runs-on: macos-14
-    environment: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && 'public-build' || 'private-build' }}
+    environment: ${{ github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && github.event_name != 'pull_request_target' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'private-build' || 'public-build' }}
     concurrency:
       group: ${{ github.workflow }}-Android-${{ github.ref }}
 
@@ -53,7 +53,7 @@ jobs:
           haxe-version: 4.3.7
 
       - name: Restore private GameAnalytics
-        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+        if: github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && github.event_name != 'pull_request_target' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}
@@ -191,7 +191,7 @@ jobs:
           
   iOS:
     runs-on: macos-15
-    environment: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && 'public-build' || 'private-build' }}
+    environment: ${{ github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && github.event_name != 'pull_request_target' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'private-build' || 'public-build' }}
     concurrency:
       group: ${{ github.workflow }}-iOS-${{ github.ref }}
 
@@ -210,7 +210,7 @@ jobs:
           haxe-version: 4.3.7
 
       - name: Restore private GameAnalytics
-        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+        if: github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && github.event_name != 'pull_request_target' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}

--- a/.github/workflows/WindowsBuild.yml
+++ b/.github/workflows/WindowsBuild.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   Windows:
     runs-on: windows-latest
-    environment: private-build
+    environment: ${{ github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && 'private-build' || 'public-build' }}
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -18,7 +18,7 @@ jobs:
           haxe-version: 4.3.7
 
       - name: Restore private GameAnalytics
-        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+        if: github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}

--- a/.github/workflows/WindowsBuild.yml
+++ b/.github/workflows/WindowsBuild.yml
@@ -24,7 +24,7 @@ jobs:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}
           NOVA_GA_TYPES_B64: ${{ secrets.NOVA_GA_TYPES_B64 }}
           NOVA_GA_CONFIG_B64: ${{ secrets.NOVA_GA_CONFIG_B64 }}
-        run: ./tools/restore-private-gameanalytics.ps1
+        run: ./tools/restore-private-gameanalytics.ps1 -Required
 
       - name: Install Libraries
         run: |

--- a/.github/workflows/WindowsZGCBuild.yml
+++ b/.github/workflows/WindowsZGCBuild.yml
@@ -124,7 +124,7 @@ jobs:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}
           NOVA_GA_TYPES_B64: ${{ secrets.NOVA_GA_TYPES_B64 }}
           NOVA_GA_CONFIG_B64: ${{ secrets.NOVA_GA_CONFIG_B64 }}
-        run: ./tools/restore-private-gameanalytics.ps1
+        run: ./tools/restore-private-gameanalytics.ps1 -Required
 
       - name: Install project libraries
         shell: pwsh
@@ -192,9 +192,10 @@ jobs:
             "-Dcommit_sha=$commitSha",
             "-Dbuild_number=$buildNumber"
           )
-          if ($env:NOVA_GAMEANALYTICS_DEFINE) {
-            $arguments += $env:NOVA_GAMEANALYTICS_DEFINE
+          if ($env:NOVA_GAMEANALYTICS_DEFINE -ne '-Dgameanalytics_enabled') {
+            throw 'Windows ZGC artifacts require the private GameAnalytics build'
           }
+          $arguments += $env:NOVA_GAMEANALYTICS_DEFINE
 
           haxe --version
           haxelib @arguments
@@ -231,11 +232,31 @@ jobs:
             throw 'Generated sources do not contain the current NovaGC descriptor ABI'
           }
 
-          $options = Get-Content -LiteralPath $optionsPath -Raw
-          if ($options -notmatch '(?m)^hxcpp_zgc=1$' -or
-              $options -notmatch '(?m)^novagc_precise=1$' -or
-              $options -match '(?m)^legacy_gc_compare=') {
-            throw 'Build options do not select the isolated ZGC configuration'
+          $optionLines = @(
+            Get-Content -LiteralPath $optionsPath |
+              ForEach-Object { $_.Trim() }
+          )
+          $requiredOptions = @('hxcpp_zgc=1', 'novagc_precise=1')
+          $missingOptions = @(
+            $requiredOptions |
+              Where-Object { $optionLines -notcontains $_ }
+          )
+          $legacyOptions = @(
+            $optionLines |
+              Where-Object { $_ -like 'legacy_gc_compare=*' }
+          )
+          if ($missingOptions.Count -gt 0 -or $legacyOptions.Count -gt 0) {
+            $details = @()
+            if ($missingOptions.Count -gt 0) {
+              $details += 'missing: ' + ($missingOptions -join ', ')
+            }
+            if ($legacyOptions.Count -gt 0) {
+              $details += 'forbidden: ' + ($legacyOptions -join ', ')
+            }
+            throw (
+              'Build options do not select the isolated ZGC configuration (' +
+              ($details -join '; ') + ')'
+            )
           }
 
           Write-Output 'NovaGC precise ABI verification passed.'

--- a/.github/workflows/WindowsZGCBuild.yml
+++ b/.github/workflows/WindowsZGCBuild.yml
@@ -54,16 +54,20 @@ jobs:
         shell: pwsh
         run: |
           $bash = 'C:\msys64\usr\bin\bash.exe'
+          $mingwRoot = 'C:\msys64\mingw64'
+          $mingwBin = Join-Path $mingwRoot 'bin'
+          $compiler = Join-Path $mingwBin 'g++.exe'
           if (-not (Test-Path -LiteralPath $bash -PathType Leaf)) {
             throw "MSYS2 bash is missing: $bash"
           }
 
-          & $bash -lc 'pacman -Sy --noconfirm --needed mingw-w64-x86_64-pcre2 mingw-w64-x86_64-mbedtls'
+          & $bash -lc 'pacman -Sy --noconfirm --needed mingw-w64-x86_64-gcc mingw-w64-x86_64-pcre2 mingw-w64-x86_64-mbedtls'
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to install NovaGC native dependencies (exit $LASTEXITCODE)"
           }
 
           $required = @(
+            $compiler,
             'C:\msys64\mingw64\include\pcre2.h',
             'C:\msys64\mingw64\include\mbedtls\ctr_drbg.h',
             'C:\msys64\mingw64\lib\libpcre2-16.a',
@@ -76,6 +80,42 @@ jobs:
               throw "NovaGC native dependency is missing after installation: $path"
             }
           }
+
+          $mingwBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "CXX=$compiler" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $env:PATH = "$mingwBin;$env:PATH"
+          $env:CXX = $compiler
+
+          $probeSource = Join-Path $env:RUNNER_TEMP 'novagc-native-deps-probe.cpp'
+          $probeBinary = Join-Path $env:RUNNER_TEMP 'novagc-native-deps-probe.exe'
+          @'
+          #define PCRE2_STATIC
+          #define PCRE2_CODE_UNIT_WIDTH 16
+          #include <pcre2.h>
+          #include <mbedtls/ctr_drbg.h>
+
+          int main() {
+              auto regexConfig = &pcre2_config;
+              mbedtls_ctr_drbg_context random;
+              mbedtls_ctr_drbg_init(&random);
+              mbedtls_ctr_drbg_free(&random);
+              return regexConfig == nullptr;
+          }
+          '@ | Set-Content -LiteralPath $probeSource -Encoding utf8
+
+          & $compiler --version
+          & $compiler -std=c++20 -static $probeSource -o $probeBinary `
+            -lpcre2-16 -lmbedtls -lmbedx509 -lmbedcrypto `
+            -lws2_32 -lcrypt32 -lbcrypt
+          if ($LASTEXITCODE -ne 0) {
+            throw "NovaGC native dependency probe failed to compile or link (exit $LASTEXITCODE)"
+          }
+
+          & $probeBinary
+          if ($LASTEXITCODE -ne 0) {
+            throw "NovaGC native dependency probe failed to run (exit $LASTEXITCODE)"
+          }
+          Write-Output "NovaGC native dependency probe passed with $compiler"
 
       - name: Restore private GameAnalytics
         if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
@@ -126,6 +166,11 @@ jobs:
           $toolchain = Join-Path $env:GITHUB_WORKSPACE 'toolchains\haxe-novagc'
           $env:PATH = "$toolchain;$env:PATH"
           $env:HAXE_STD_PATH = Join-Path $toolchain 'std'
+
+          $expectedCompiler = 'C:\msys64\mingw64\bin\g++.exe'
+          if ([IO.Path]::GetFullPath($env:CXX) -ne [IO.Path]::GetFullPath($expectedCompiler)) {
+            throw "Unexpected NovaGC C++ compiler: $env:CXX"
+          }
 
           $selectedHaxe = (Get-Command haxe.exe -ErrorAction Stop).Source
           $expectedHaxe = Join-Path $toolchain 'haxe.exe'

--- a/.github/workflows/WindowsZGCBuild.yml
+++ b/.github/workflows/WindowsZGCBuild.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   Windows-ZGC:
     runs-on: windows-latest
-    environment: private-build
+    environment: ${{ github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && 'private-build' || 'public-build' }}
     timeout-minutes: 180
     env:
       HXCPP_COMPILE_JOBS: 4
@@ -118,7 +118,7 @@ jobs:
           Write-Output "NovaGC native dependency probe passed with $compiler"
 
       - name: Restore private GameAnalytics
-        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+        if: github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}
@@ -192,10 +192,16 @@ jobs:
             "-Dcommit_sha=$commitSha",
             "-Dbuild_number=$buildNumber"
           )
-          if ($env:NOVA_GAMEANALYTICS_DEFINE -ne '-Dgameanalytics_enabled') {
-            throw 'Windows ZGC artifacts require the private GameAnalytics build'
+          $isOfficialRepository = (
+            '${{ github.repository }}' -eq
+            'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine'
+          )
+          if ($isOfficialRepository) {
+            if ($env:NOVA_GAMEANALYTICS_DEFINE -ne '-Dgameanalytics_enabled') {
+              throw 'Official Windows ZGC artifacts require private GameAnalytics'
+            }
+            $arguments += $env:NOVA_GAMEANALYTICS_DEFINE
           }
-          $arguments += $env:NOVA_GAMEANALYTICS_DEFINE
 
           haxe --version
           haxelib @arguments

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,7 +11,7 @@ jobs:
   buildAndroid:
     name: buildAndroid
     runs-on: ubuntu-latest
-    environment: private-build
+    environment: ${{ github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && 'private-build' || 'public-build' }}
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -34,7 +34,7 @@ jobs:
           haxe-version: 4.3.7
 
       - name: Restore private GameAnalytics
-        if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+        if: github.repository == 'NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         shell: pwsh
         env:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -40,7 +40,7 @@ jobs:
           NOVA_GA_IMPL_B64: ${{ secrets.NOVA_GA_IMPL_B64 }}
           NOVA_GA_TYPES_B64: ${{ secrets.NOVA_GA_TYPES_B64 }}
           NOVA_GA_CONFIG_B64: ${{ secrets.NOVA_GA_CONFIG_B64 }}
-        run: ./tools/restore-private-gameanalytics.ps1
+        run: ./tools/restore-private-gameanalytics.ps1 -Required
       
       - name: Restore Previous Cache
         id: cache-debug-build-android-restore

--- a/tools/restore-private-gameanalytics.ps1
+++ b/tools/restore-private-gameanalytics.ps1
@@ -1,7 +1,8 @@
 param(
     [string]$TargetDirectory = (
         Join-Path $PSScriptRoot '..\private\gameanalytics'
-    )
+    ),
+    [switch]$Required
 )
 
 $ErrorActionPreference = 'Stop'
@@ -21,6 +22,13 @@ $missing = @(
 $githubEnvironment = $env:GITHUB_ENV
 
 if ($missing.Count -gt 0) {
+    if ($Required) {
+        throw (
+            'Required private GameAnalytics sources are unavailable: ' +
+            ($missing -join ', ')
+        )
+    }
+
     if (-not [string]::IsNullOrWhiteSpace($githubEnvironment)) {
         [IO.File]::AppendAllText(
             $githubEnvironment,


### PR DESCRIPTION
## Root causes
- Windows ZGC installed PCRE2 and mbedTLS without pinning the matching MSYS2 MinGW C++ compiler, so NovaGC could select an incompatible `g++`.
- The post-build `Options.txt` verifier read CRLF text with LF-only regular expressions, causing a false failure after the full ZGC build had already succeeded.
- Official release builds could silently continue without the private GameAnalytics sources when secrets were missing.

Failed runs:
- native toolchain: https://github.com/NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine/actions/runs/30271798681
- CRLF verifier: https://github.com/NovaFlare-Engine-Concentration/FNF-NovaFlare-Engine/actions/runs/30325342402

## Fix
- install and pin `mingw-w64-x86_64-gcc` with PCRE2 and mbedTLS
- reject an unexpected compiler and run a static PCRE2/mbedTLS probe before the expensive build
- verify ZGC options as normalized lines, so Windows CRLF is handled correctly
- require private GameAnalytics sources for trusted builds in the official NovaFlare repository
- route fork repositories and external fork PRs to `public-build`; they skip GameAnalytics and do not fail for missing private secrets
- require the private analytics define explicitly only for official Windows ZGC builds

## Release behavior
- Release continues to call only `MobileBuild.yml`, `MacBuild.yml`, `WindowsBuild.yml`, and `LinuxBuild.yml`
- Release does not call `WindowsZGCBuild.yml` or download/publish the `windows-zgc-*` artifact
- an official NovaFlare Release fails closed if its private GameAnalytics inputs are missing
- a forked repository can build and release its public version without those private inputs

## Validation
- `actionlint` passes
- `git diff --check` passes
- PowerShell parser passes for the private restore helper
- required-private-source failure mode passes
- CRLF-safe ZGC option verifier test passes
- full ZGC compilation succeeded in run 30325342402; final ABI/package rerun pending